### PR TITLE
Mercurial support

### DIFF
--- a/source/commands/danger-local.ts
+++ b/source/commands/danger-local.ts
@@ -4,7 +4,8 @@ import program from "commander"
 
 import setSharedArgs, { SharedCLI } from "./utils/sharedDangerfileArgs"
 import { runRunner } from "./ci/runner"
-import { LocalGit } from "../platforms/LocalGit"
+import { isGitRepo, LocalGit } from "../platforms/LocalGit"
+import { isHgRepo, LocalHg } from "../platforms/LocalHg"
 import { FakeCI } from "../ci_source/providers/Fake"
 
 interface App extends SharedCLI {
@@ -16,22 +17,45 @@ interface App extends SharedCLI {
 
 program
   .usage("[options]")
-  .description("Runs danger without PR metadata, useful for git hooks.")
+  .description("Runs danger without PR metadata, useful for SCM hooks.")
   .option("-s, --staging", "Just use staged changes.")
   .option("-b, --base [branch_name]", "Use a different base branch")
 setSharedArgs(program).parse(process.argv)
 
-const app = (program as any) as App
-const base = app.base || "master"
+const isUsingGitScm = isGitRepo()
+const isUsingHgScm = isHgRepo()
 
-const localPlatform = new LocalGit({ base, staging: app.staging })
-localPlatform.validateThereAreChanges().then(changes => {
-  if (changes) {
-    const fakeSource = new FakeCI(process.env)
-    // By setting the custom env var we can be sure that the runner doesn't
-    // try to find the CI danger is running on and use that.
-    runRunner(app, { source: fakeSource, platform: localPlatform, additionalEnvVars: { DANGER_LOCAL_NO_CI: "yep" } })
-  } else {
-    console.log(`No git changes detected between head and ${base}.`)
-  }
-})
+const app = (program as any) as App
+
+if (isUsingGitScm) {
+  const base = app.base || "master"
+  const head = "HEAD"
+
+  const localPlatform = new LocalGit({ base, staging: app.staging })
+  localPlatform.validateThereAreChanges().then(changes => {
+    if (changes) {
+      const fakeSource = new FakeCI(process.env)
+      // By setting the custom env var we can be sure that the runner doesn't
+      // try to find the CI danger is running on and use that.
+      runRunner(app, { source: fakeSource, platform: localPlatform, additionalEnvVars: { DANGER_LOCAL_NO_CI: "yep" } })
+    } else {
+      console.log(`No git changes detected between ${head} and ${base}.`)
+    }
+  })
+}
+
+if (isUsingHgScm) {
+  const base = app.base || "default"
+  const tip = "tip"
+
+  const localPlatform = new LocalHg({ base, staging: app.staging })
+  localPlatform.validateThereAreChanges().then(changes => {
+    if (changes) {
+      const fakeSource = new FakeCI(process.env)
+      runRunner(app, { source: fakeSource, platform: localPlatform, additionalEnvVars: { DANGER_LOCAL_NO_CI: "yep" } })
+    } else {
+      console.log(`No hg changes detected between ${base} and ${tip}`)
+    }
+  })
+}
+

--- a/source/dsl/Commit.ts
+++ b/source/dsl/Commit.ts
@@ -1,11 +1,17 @@
 /** A platform agnostic reference to a Git commit */
-export interface GitCommit {
+export interface GitCommit extends Commit { }
+
+/** A platform agnostic reference to a Hg commit */
+export interface HgCommit extends Commit { }
+
+/** A platform agnostic reference to a commit */
+export interface Commit {
   /** The SHA for the commit */
   sha: string
   /** Who wrote the commit */
-  author: GitCommitAuthor
+  author: CommitAuthor
   /** Who deployed the commit */
-  committer: GitCommitAuthor
+  committer: CommitAuthor
   /** The commit message */
   message: string
   /** Potential parent commits, and other assorted metadata */
@@ -17,7 +23,7 @@ export interface GitCommit {
 }
 
 /** An author of a commit */
-export interface GitCommitAuthor {
+export interface CommitAuthor {
   /** The display name for the author */
   name: string
   /** The authors email */

--- a/source/dsl/DangerDSL.ts
+++ b/source/dsl/DangerDSL.ts
@@ -1,6 +1,7 @@
 // Please don't have includes in here that aren't inside the DSL folder, or the d.ts/flow defs break
 
 import { GitDSL, GitJSONDSL } from "../dsl/GitDSL"
+import { HgDSL, HgJSONDSL } from "../dsl/HgDSL"
 import { GitHubDSL } from "../dsl/GitHubDSL"
 import { BitBucketServerDSL, BitBucketServerJSONDSL } from "../dsl/BitBucketServerDSL"
 import { DangerUtilsDSL } from "./DangerUtilsDSL"
@@ -63,6 +64,8 @@ export interface DangerDSLJSONType {
   bitbucket_cloud?: BitBucketCloudJSONDSL
   /** The data only version of GitLab DSL */
   gitlab?: GitLabDSL
+  /** the data only version of the Hg DSL */
+  hg: HgJSONDSL
   /**
    * Used in the Danger JSON DSL to pass metadata between
    * processes. It will be undefined when used inside the Danger DSL
@@ -150,6 +153,12 @@ export interface DangerDSLType {
    * is classed as non-nullable
    */
   readonly gitlab: GitLabDSL
+  /**
+   *  Details specific to the hg changes within the code changes.
+   *  Currently, this is just the raw file paths that have been
+   *  added, removed or modified.
+   */
+  readonly hg: HgDSL
 
   /**
    * Functions which are globally useful in most Dangerfiles. Right
@@ -166,7 +175,7 @@ export class DangerDSL {
   public readonly bitbucket_server?: BitBucketServerDSL
   public readonly gitlab?: GitLabDSL
 
-  constructor(platformDSL: any, public readonly git: GitJSONDSL, public readonly utils: DangerUtilsDSL, name: string) {
+  constructor(platformDSL: any, public readonly git: GitJSONDSL, public readonly hg: HgJSONDSL, public readonly utils: DangerUtilsDSL, name: string) {
     switch (name) {
       case "GitHub":
       case "Fake": // Testing only

--- a/source/dsl/Diff+Patch.ts
+++ b/source/dsl/Diff+Patch.ts
@@ -1,0 +1,70 @@
+/** Types related to Diffs and Patches, these are generics that can be used with both Git and Hg APIs */
+
+/** All Text diff values will be this shape */
+export interface TextDiff {
+  /** The value before the PR's applied changes */
+  before: string
+  /** The value after the PR's applied changes */
+  after: string
+  /** A string containing the full set of changes */
+  diff: string
+  /** A string containing just the added lines */
+  added: string
+  /** A string containing just the removed lines */
+  removed: string
+}
+
+/** Diff sliced into chunks */
+export interface StructuredDiff {
+  /** Diff chunks */
+  chunks: any[]
+}
+
+/** The results of running a JSON patch */
+export interface JSONPatch {
+  /** The JSON in a file at the PR merge base */
+  before: any
+  /** The JSON in a file from the PR submitter */
+  after: any
+  /** The set of operations to go from one JSON to another JSON */
+  diff: JSONPatchOperation[]
+}
+
+/** An individual operation inside an rfc6902 JSON Patch */
+export interface JSONPatchOperation {
+  /** An operation type */
+  op: string
+  /** The JSON keypath which the operation applies on */
+  path: string
+  /** The changes for applied */
+  value: string
+}
+
+/** All JSON diff values will be this shape */
+export interface JSONDiffValue {
+  /** The value before the PR's applied changes */
+  before: any
+  /** The value after the PR's applied changes */
+  after: any
+  /** If both before & after are arrays, then you optionally get what is added. Empty if no additional objects. */
+  added?: any[]
+  /** If both before & after are arrays, then you optionally get what is removed. Empty if no removed objects. */
+  removed?: any[]
+}
+
+/** A map of string keys to JSONDiffValue */
+export interface JSONDiff {
+  [name: string]: JSONDiffValue
+}
+
+/** The shape of the Chainsmoker response */
+export interface MatchResult {
+  /** Did any file paths match from the git modified list? */
+  modified: any
+  /** Did any file paths match from the git created list? */
+  created: any
+  /** Did any file paths match from the combination of the git modified and created list? */
+  edited: any
+  /** Did any file paths match from the git deleted list? */
+  deleted: any
+}

--- a/source/dsl/HgDSL.ts
+++ b/source/dsl/HgDSL.ts
@@ -1,44 +1,42 @@
-// Please don't have includes in here that aren't inside the DSL folder, or the d.ts/flow defs break
 
 import { JSONDSL } from "./JSONDSL"
-import { GitCommit } from "./Commit"
+import { HgCommit } from "./Commit"
 import { Chainsmoker } from "../commands/utils/chainsmoker"
 import { TextDiff, StructuredDiff, JSONPatch, JSONDiff, MatchResult } from "./Diff+Patch"
 
-// This is `danger.git`
+// This is `danger.hg`
 
 /**
  *
- * The Git Related Metadata which is available inside the Danger DSL JSON
+ * The Mercurial Related Metadata which is available inside the Danger DSL JSON
  *
  * @namespace JSONDSL
  */
-export interface GitJSONDSL extends JSONDSL {
-  /** The Git commit metadata */
-  readonly commits: GitCommit[]
+export interface HgJSONDSL extends JSONDSL {
+  /** The Mercurial commit metadata */
+  readonly commits: HgCommit[]
 }
 
-/** The git specific metadata for a PR */
-export interface GitDSL extends GitJSONDSL {
+export interface HgDSL extends HgJSONDSL {
   /**
    * A Chainsmoker object to help match paths as an elegant DSL. It
    * lets you write a globbed string and then get booleans on whether
-   * there are matches within a certain part of the git DSL.
+   * there are matches within a certain part of the hg DSL.
    *
    * Use this to create an object which has booleans set on 4 keys
    * `modified`, `created`, `edited` (created + modified) and `deleted`.
    *
    * @example
-   * const packageJSON = danger.git.fileMatch("package.json")
-   * const lockfile = danger.git.fileMatch("yarn.lock")
+   * const packageJSON = danger.hg.fileMatch("package.json")
+   * const lockfile = danger.hg.fileMatch("yarn.lock")
    *
    * if (packageJSON.modified && !lockfile.modified) {
    *    warn("You might have forgotten to run `yarn`.")
    * }
    *
    * @example
-   * const needsSchemaChange = danger.git.fileMatch("src/app/analytics/*.ts")
-   * const schema = danger.git.fileMatch("src/app/analytics/schema.ts")
+   * const needsSchemaChange = danger.hg.fileMatch("src/app/analytics/*.ts")
+   * const schema = danger.hg.fileMatch("src/app/analytics/schema.ts")
    *
    * if (needsSchemaChange.edited && !schema.modified) {
    *    fail("Changes to the analytics files need to edit update the schema.")

--- a/source/dsl/JSONDSL.ts
+++ b/source/dsl/JSONDSL.ts
@@ -1,0 +1,29 @@
+
+import { Commit } from "./Commit"
+
+/**
+ *
+ * Related Metadata which is available inside the Danger DSL JSON
+ *
+ * @namespace JSONDSL
+ */
+
+export interface JSONDSL {
+    /**
+     * Filepaths with changes relative to the scm root
+     */
+    readonly modified_files: string[]
+
+    /**
+     * Newly created filepaths relative to the scm root
+     */
+    readonly created_files: string[]
+
+    /**
+     * Removed filepaths relative to the scm root
+     */
+    readonly deleted_files: string[]
+
+    /** The commit metadata */
+    readonly commits: Commit[]
+}

--- a/source/platforms/BitBucketCloud.ts
+++ b/source/platforms/BitBucketCloud.ts
@@ -27,7 +27,7 @@ export class BitBucketCloud implements Platform {
    *
    * @returns {Promise<GitDSL>} the git DSL
    */
-  getPlatformGitRepresentation = (): Promise<GitJSONDSL> => gitDSLForBitBucketCloud(this.api)
+  getPlatformSCMRepresentation = (): Promise<GitJSONDSL> => gitDSLForBitBucketCloud(this.api)
 
   /**
    * Returns the `bitbucket_cloud` object on the Danger DSL

--- a/source/platforms/BitBucketServer.ts
+++ b/source/platforms/BitBucketServer.ts
@@ -28,7 +28,7 @@ export class BitBucketServer implements Platform {
    *
    * @returns {Promise<GitDSL>} the git DSL
    */
-  getPlatformGitRepresentation = (): Promise<GitJSONDSL> => gitDSLForBitBucketServer(this.api)
+  getPlatformSCMRepresentation = (): Promise<GitJSONDSL> => gitDSLForBitBucketServer(this.api)
 
   /**
    * Gets inline comments for current PR

--- a/source/platforms/FakePlatform.ts
+++ b/source/platforms/FakePlatform.ts
@@ -18,7 +18,7 @@ export class FakePlatform implements Platform {
     return {}
   }
 
-  async getPlatformGitRepresentation(): Promise<GitDSL> {
+  async getPlatformSCMRepresentation(): Promise<GitDSL> {
     return {
       modified_files: [],
       created_files: [],

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -36,7 +36,7 @@ export function GitHub(api: GitHubAPI) {
 
     api,
     getReviewInfo: api.getPullRequestInfo,
-    getPlatformGitRepresentation: () => gitDSLForGitHub(api),
+    getPlatformSCMRepresentation: () => gitDSLForGitHub(api),
 
     getPlatformReviewDSLRepresentation: async () => {
       let pr: GitHubPRDSL

--- a/source/platforms/GitLab.ts
+++ b/source/platforms/GitLab.ts
@@ -30,7 +30,7 @@ class GitLab implements Platform {
     }
   }
 
-  getPlatformGitRepresentation = async (): Promise<GitJSONDSL> => {
+  getPlatformSCMRepresentation = async (): Promise<GitJSONDSL> => {
     const changes = await this.api.getMergeRequestChanges()
     const commits = await this.api.getMergeRequestCommits()
 

--- a/source/platforms/LocalGit.ts
+++ b/source/platforms/LocalGit.ts
@@ -6,11 +6,15 @@ import { GitCommit } from "../dsl/Commit"
 import { localGetDiff } from "./git/localGetDiff"
 import { localGetFileAtSHA } from "./git/localGetFileAtSHA"
 import { localGetCommits } from "./git/localGetCommits"
-import { readFileSync } from "fs"
+import { readFileSync, existsSync } from "fs"
 
 export interface LocalGitOptions {
   base?: string
   staging?: boolean
+}
+
+export function isGitRepo(): boolean {
+  return existsSync(".git/")
 }
 
 export class LocalGit implements Platform {
@@ -41,7 +45,7 @@ export class LocalGit implements Platform {
     return null
   }
 
-  async getPlatformGitRepresentation(): Promise<GitDSL> {
+  async getPlatformSCMRepresentation(): Promise<GitDSL> {
     const base = this.options.base || "master"
     const head = "HEAD"
     const diff = await this.getGitDiff()

--- a/source/platforms/LocalHg.ts
+++ b/source/platforms/LocalHg.ts
@@ -1,0 +1,116 @@
+import { HgDSL } from "../dsl/HgDSL"
+import { Platform, Comment } from "./platform"
+import { hgJSONToHgDSL, HgJSONToHgDSLConfig } from "./hg/hgJSONToHgDSL"
+import { diffToHgJSONDSL } from "./hg/diffToHgJSONDSL"
+import { HgCommit } from "../dsl/Commit"
+import { localGetDiff } from "./hg/localGetDiff"
+import { localGetFileAtSHA } from "./hg/localGetFileAtSHA"
+import { localGetCommits } from "./hg/localGetCommits"
+import { readFileSync, existsSync } from "fs"
+
+export interface LocalHgOptions {
+  base?: string
+  staging?: boolean
+}
+
+export function isHgRepo(): boolean {
+  return existsSync(".hg/")
+}
+
+export class LocalHg implements Platform {
+  public readonly name: string
+  private hgDiff: string | undefined
+
+  constructor(public readonly options: LocalHgOptions) {
+    this.name = "local hg"
+  }
+
+  async getHgDiff(): Promise<string> {
+    if (this.hgDiff) {
+      return this.hgDiff
+    }
+    const base = this.options.base || "default"
+    const tip = "tip"
+
+    this.hgDiff = await localGetDiff(base, tip, this.options.staging)
+    return this.hgDiff
+  }
+
+  async validateThereAreChanges(): Promise<boolean> {
+    const diff = await this.getHgDiff()
+    return diff.trim().length > 0
+  }
+
+  async getPlatformReviewDSLRepresentation(): Promise<any> {
+    return null
+  }
+
+  async getPlatformSCMRepresentation(): Promise<HgDSL> {
+    const base = this.options.base || "default"
+    const tip = "tip"
+    const diff = await this.getHgDiff()
+    const commits: HgCommit[] = await localGetCommits(base, tip)
+    const hgJSON = diffToHgJSONDSL(diff, commits)
+
+    const config: HgJSONToHgDSLConfig = {
+      repo: process.cwd(),
+      baseSHA: this.options.base || "",
+      headSHA: "",
+      getFileContents: localGetFileAtSHA,
+      getFullDiff: localGetDiff,
+    }
+
+    return hgJSONToHgDSL(hgJSON, config)
+  }
+
+  async getInlineComments(_: string): Promise<Comment[]> {
+    return []
+  }
+
+  supportsCommenting() {
+    return false
+  }
+
+  supportsInlineComments() {
+    return true
+  }
+
+  async updateOrCreateComment(_dangerID: string, _newComment: string): Promise<string | undefined> {
+    return undefined
+  }
+
+  async createComment(_comment: string): Promise<any> {
+    return true
+  }
+
+  async createInlineComment(_git: HgDSL, _comment: string, _path: string, _line: number): Promise<any> {
+    return true
+  }
+
+  async updateInlineComment(_comment: string, _commentId: string): Promise<any> {
+    return true
+  }
+
+  async deleteInlineComment(_id: string): Promise<boolean> {
+    return true
+  }
+
+  async deleteMainComment(): Promise<boolean> {
+    return true
+  }
+
+  async editMainComment(_comment: string): Promise<boolean> {
+    return true
+  }
+
+  async updateStatus(): Promise<boolean> {
+    return true
+  }
+
+  getFileContents = (path: string) => new Promise<string>(res => res(readFileSync(path, "utf8")))
+
+  async getReviewInfo(): Promise<any> {
+    return {}
+  }
+}
+

--- a/source/platforms/git/localGetDiff.ts
+++ b/source/platforms/git/localGetDiff.ts
@@ -21,7 +21,7 @@ export const localGetDiff = (base: string, head: string, staging: boolean = fals
       throw new Error(data.toString())
     })
 
-    child.on("close", function(code) {
+    child.on("close", function (code) {
       if (code === 0) {
         done(stdout)
       }

--- a/source/platforms/hg/_tests/localGetCommits.test.ts
+++ b/source/platforms/hg/_tests/localGetCommits.test.ts
@@ -1,0 +1,10 @@
+import { formatJSON } from "../localGetCommits"
+
+it("generates a JSON-like commit message", () => {
+  expect(formatJSON).toEqual(
+    '\{ "sha": "{node}", "parents": "{parents}", "author": \{"name": "{author|person}", "email": "{author|email}", "date": "{date|isodate}" \}, "committer": \{"name": "{author|person}", "email": "{author|email}", "date": "{date|isodate}" \}, "message": "{desc}"\},'
+  )
+
+  const withoutComma = formatJSON.substring(0, formatJSON.length - 1)
+  expect(() => JSON.parse(withoutComma)).not.toThrow()
+})

--- a/source/platforms/hg/_tests/local_dangerfile_example.ts
+++ b/source/platforms/hg/_tests/local_dangerfile_example.ts
@@ -1,0 +1,31 @@
+// This dangerfile is for running as an integration test on CI
+
+import { DangerDSLType } from "../../../dsl/DangerDSL"
+declare var danger: DangerDSLType
+declare function markdown(params: string): void
+
+const showArray = (array: any[], mapFunc?: (a: any) => any) => {
+  const defaultMap = (a: any) => a
+  const mapper = mapFunc || defaultMap
+  return `\n - ${array.map(mapper).join("\n - ")}\n`
+}
+
+const hg = danger.hg
+
+const goAsync = async () => {
+  const firstFileDiff = await hg.diffForFile(hg.modified_files[0])
+  const firstJSONFile = hg.modified_files.find(f => f.endsWith("json"))
+  const jsonDiff = firstJSONFile && (await hg.JSONDiffForFile(firstJSONFile))
+  const jsonDiffKeys = jsonDiff && showArray(Object.keys(jsonDiff))
+
+  markdown(`
+created: ${showArray(hg.created_files)}
+modified: ${showArray(hg.modified_files)}
+deleted: ${showArray(hg.deleted_files)}
+commits: ${hg.commits.length}
+messages: ${showArray(hg.commits, c => c.message)}
+diffForFile keys:${firstFileDiff && showArray(Object.keys(firstFileDiff))}
+jsonDiff keys:${jsonDiffKeys || "no JSON files in the diff"}
+`)
+}
+goAsync()

--- a/source/platforms/hg/diffToHgJSONDSL.ts
+++ b/source/platforms/hg/diffToHgJSONDSL.ts
@@ -1,0 +1,25 @@
+import parseDiff from "parse-diff"
+import includes from "lodash.includes"
+import { HgCommit } from "../../dsl/Commit"
+import { HgJSONDSL } from "../../dsl/HgDSL"
+
+/**
+ * This function is essentially a "go from a diff to some simple structured data"
+ * it's the steps needed for danger process.
+ */
+
+export const diffToHgJSONDSL = (diff: string, commits: HgCommit[]): HgJSONDSL => {
+  const fileDiffs: any[] = parseDiff(diff)
+
+  const addedDiffs = fileDiffs.filter((diff: any) => diff["new"])
+  const removedDiffs = fileDiffs.filter((diff: any) => diff["deleted"])
+  const modifiedDiffs = fileDiffs.filter((diff: any) => !includes(addedDiffs, diff) && !includes(removedDiffs, diff))
+
+  return {
+    //                                             Work around for danger/danger-js#807
+    modified_files: modifiedDiffs.map(d => d.to || (d.from && d.from.split(" b/")[0])),
+    created_files: addedDiffs.map(d => d.to),
+    deleted_files: removedDiffs.map(d => d.from),
+    commits: commits,
+  }
+}

--- a/source/platforms/hg/localGetCommits.ts
+++ b/source/platforms/hg/localGetCommits.ts
@@ -1,0 +1,46 @@
+import { debug } from "../../debug"
+import JSON5 from "json5"
+
+import { spawn } from "child_process"
+import { HgCommit } from "../../dsl/Commit"
+
+const d = debug("localGetDiff")
+
+const sha = "{node}"
+const parents = "{parents}"
+const authorName = "{author|person}"
+const authorEmail = "{author|email}"
+const authorDate = "{date|isodate}"
+const committerName = "{author|person}"
+const committerEmail = "{author|email}"
+const committerDate = "{date|isodate}"
+const message = "{desc}" // this is subject, not message, so it'll only be one line
+
+const author = `"author": \{"name": "${authorName}", "email": "${authorEmail}", "date": "${authorDate}" \}`
+const committer = `"committer": \{"name": "${committerName}", "email": "${committerEmail}", "date": "${committerDate}" \}`
+export const formatJSON = `\{ "sha": "${sha}", "parents": "${parents}", ${author}, ${committer}, "message": "${message}"\},`
+
+export const localGetCommits = (base: string, tip: string) =>
+  new Promise<HgCommit[]>(done => {
+    const args = ["log", `${base}...${tip}`, `--template ${formatJSON}`]
+    const child = spawn("hg", args, { env: process.env })
+    d("> hg", args.join(" "))
+    child.stdout.on("data", async data => {
+      data = data.toString()
+
+      // remove trailing comma, and wrap into an array
+      const asJSONString = `[${data.substring(0, data.length - 1)}]`
+      const commits = JSON5.parse(asJSONString)
+      const realCommits = commits.map((c: any) => ({
+        ...c,
+        parents: c.parents.split(" "),
+      }))
+
+      done(realCommits)
+    })
+
+    child.stderr.on("data", data => {
+      console.error(`Could not get commits from hg between ${base} and ${tip}`)
+      throw new Error(data.toString())
+    })
+  })

--- a/source/platforms/hg/localGetCommits.ts
+++ b/source/platforms/hg/localGetCommits.ts
@@ -20,9 +20,9 @@ const author = `"author": \{"name": "${authorName}", "email": "${authorEmail}", 
 const committer = `"committer": \{"name": "${committerName}", "email": "${committerEmail}", "date": "${committerDate}" \}`
 export const formatJSON = `\{ "sha": "${sha}", "parents": "${parents}", ${author}, ${committer}, "message": "${message}"\},`
 
-export const localGetCommits = (base: string, tip: string) =>
+export const localGetCommits = (base: string, tip: string = "tip") =>
   new Promise<HgCommit[]>(done => {
-    const args = ["log", `${base}...${tip}`, `--template ${formatJSON}`]
+    const args = ["log", `--rev ${base}:${tip}`, `--template ${formatJSON}`]
     const child = spawn("hg", args, { env: process.env })
     d("> hg", args.join(" "))
     child.stdout.on("data", async data => {

--- a/source/platforms/hg/localGetDiff.ts
+++ b/source/platforms/hg/localGetDiff.ts
@@ -1,0 +1,29 @@
+import { debug } from "../../debug"
+import { spawn } from "child_process"
+
+const d = debug("localGetDiff")
+const useCommittedDiffArgs = (base: string, tip: string) => ["diff", `-r ${base}:${tip}`]
+const useStagingChanges = (base: string) => ["diff", `-r ${base}`]
+export const localGetDiff = (base: string, tip: string, staging: boolean = false) =>
+  new Promise<string>(done => {
+    const args = staging ? useStagingChanges(base) : useCommittedDiffArgs(base, tip)
+    let stdout = ""
+
+    const child = spawn("hg", args, { env: process.env })
+    d("> hg", args.join(" "))
+
+    child.stdout.on("data", chunk => {
+      stdout += chunk
+    })
+
+    child.stderr.on("data", data => {
+      console.error(`Could not get diff from hg between ${base} and ${tip}`)
+      throw new Error(data.toString())
+    })
+
+    child.on("close", function (code) {
+      if (code === 0) {
+        done(stdout)
+      }
+    })
+  })

--- a/source/platforms/hg/localGetDiff.ts
+++ b/source/platforms/hg/localGetDiff.ts
@@ -2,8 +2,8 @@ import { debug } from "../../debug"
 import { spawn } from "child_process"
 
 const d = debug("localGetDiff")
-const useCommittedDiffArgs = (base: string, tip: string) => ["diff", `-r ${base}:${tip}`]
-const useStagingChanges = (base: string) => ["diff", `-r ${base}`]
+const useCommittedDiffArgs = (base: string, tip: string) => ["diff", `--rev ${base}:${tip}`]
+const useStagingChanges = (base: string) => ["diff", `--rev ${base}`]
 export const localGetDiff = (base: string, tip: string, staging: boolean = false) =>
   new Promise<string>(done => {
     const args = staging ? useStagingChanges(base) : useCommittedDiffArgs(base, tip)

--- a/source/platforms/hg/localGetFileAtSHA.ts
+++ b/source/platforms/hg/localGetFileAtSHA.ts
@@ -1,0 +1,20 @@
+import { debug } from "../../debug"
+import { exec } from "child_process"
+
+const d = debug("localGetFileAtSHA")
+
+export const localGetFileAtSHA = (path: string, _repo: string | undefined, sha: string) =>
+  new Promise<string>(done => {
+    const call = `hg cat --rev ${sha} "${path}"`
+    d(call)
+
+    exec(call, (err, stdout, _stderr) => {
+      if (err) {
+        console.error(`Could not get the file ${path} from hg at ${sha}`)
+        console.error(err)
+        return
+      }
+
+      done(stdout)
+    })
+  })

--- a/source/platforms/platform.ts
+++ b/source/platforms/platform.ts
@@ -1,5 +1,6 @@
 import { CISource, Env } from "../ci_source/ci_source"
-import { GitDSL, GitJSONDSL } from "../dsl/GitDSL"
+import { GitDSL } from "../dsl/GitDSL"
+import { JSONDSL } from "../dsl/JSONDSL"
 import { GitHub } from "./GitHub"
 import { GitHubAPI } from "./github/GitHubAPI"
 import { BitBucketServer } from "./BitBucketServer"
@@ -45,7 +46,7 @@ export interface Platform extends PlatformCommunicator {
   /** Pulls in the platform specific metadata for event runs */
   getPlatformReviewSimpleRepresentation?: () => Promise<any>
   /** Pulls in the Code Review Diff, and offers a succinct user-API for it */
-  getPlatformGitRepresentation: () => Promise<GitJSONDSL>
+  getPlatformSCMRepresentation: () => Promise<JSONDSL>
   /** Get the contents of a file at a path */
   getFileContents: (path: string, slug?: string, ref?: string) => Promise<string>
   /** Optional: Wrap the danger evaluation with some of your code */
@@ -148,7 +149,7 @@ export function getPlatformForEnv(env: Env, source: CISource): Platform {
   // They need to set the token up for GitHub actions to work
   if (env["GITHUB_EVENT_NAME"] && !ghToken) {
     console.error(`You need to add GITHUB_TOKEN to your Danger action in the workflow:
-  
+
     - name: Danger JS
       uses: danger/danger-js@X.Y.Z
       ${chalk.green(`env:

--- a/source/runner/dangerDSLJSON.ts
+++ b/source/runner/dangerDSLJSON.ts
@@ -1,5 +1,6 @@
 import { DangerDSLJSONType } from "../dsl/DangerDSL"
 import { GitJSONDSL } from "../dsl/GitDSL"
+import { HgJSONDSL } from "../dsl/HgDSL"
 import { GitHubDSL } from "../dsl/GitHubDSL"
 import { CliArgs } from "../dsl/cli-args"
 
@@ -14,6 +15,8 @@ export class DangerDSLJSON implements DangerDSLJSONType {
 
   // @ts-ignore
   git: GitJSONDSL
+  // @ts-ignore
+  hg: HgJSONDSL
   // @ts-ignore
   github: GitHubDSL
   // @ts-ignore


### PR DESCRIPTION
This is a first-pass at adding Mercurial support to danger. As such, the implementation is `LocalHg` and mirrors the existing `LocalGit` implementation. These two SCMs use some of the same language and concepts, so a lot of the existing code starts to seem to reference "git" unnecessarily (where referencing a generic SCM makes more sense). This is my first real foray into using Typescript, so i expect that there could be some errors. I have used existing styling rules and code formatting as a guide so I don't think there is that much that needs changing.

i guess i should also mention that i have some interest in adding support for subversion as well; so being able to remove much of the `Git` specific prefixing on classes and types would make it easier to work with - as well as making it easier to add other SCM hosting platforms you see in enterprise rather than the newer cloud-based platforms.

